### PR TITLE
This adds support for the use of nonces

### DIFF
--- a/action.php
+++ b/action.php
@@ -89,6 +89,11 @@ class action_plugin_cspheader extends DokuWiki_Action_Plugin
             $cspheader .= " $directive $value;";
         }
 
+        // create nonce for inline scripts and replace placeholder in header
+        $nonce = bin2hex(random_bytes(16));
+        putenv("NONCE=$nonce");
+        $cspheader = str_replace('NONCE', $nonce, $cspheader);
+
         array_push($event->data, $cspheader);
     }
 }


### PR DESCRIPTION
The change will ininitialize a random nonce on every call and add it to the environment from where it will be picked up by the changes introduced in https://github.com/dokuwiki/dokuwiki/pull/4220

Users may use that nonce in their CSP directives by using the placeholder NONCE. Eg the script-src dirctive might use 'nonce-NONCE' resulting in a header script-src: 'nonce-1cccd1f6fb2939edd9fa9372b67017b3'; or similar.